### PR TITLE
Configure nginx to access ZM cache

### DIFF
--- a/overlay/usr/local/etc/nginx/conf.d/zoneminder.conf
+++ b/overlay/usr/local/etc/nginx/conf.d/zoneminder.conf
@@ -6,6 +6,10 @@ server {
 	try_files $uri $uri/ /index.php$is_args$args;
 	index index.php;
 
+	location /cache {
+		alias /var/cache/zoneminder;
+	}
+
 	location = /cgi-bin/nph-zms {
 		include fastcgi_params;
 		fastcgi_param   SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
Without these lines, the majority of CSS and JS resources within ZM are broken, leading to a broken and only partially-functioning web UI.  This fixes this major issue by making the cache path available to web requests.