### PR TITLE
Update nginx config to match ZM port guidelines

### DIFF
--- a/overlay/usr/local/etc/nginx/conf.d/zoneminder.conf
+++ b/overlay/usr/local/etc/nginx/conf.d/zoneminder.conf
@@ -1,29 +1,42 @@
 server {
-  listen 80;
-  server_name _;
+    listen 80;
+    server_name _;
+    root /usr/local/www/zoneminder;
+    index index.php;
 
-	root /usr/local/www/zoneminder;
-	try_files $uri $uri/ /index.php$is_args$args;
-	index index.php;
+    location = / {
+        return 302 /zm/;
+    }
 
-	location /cache {
-		alias /var/cache/zoneminder;
-	}
+    location /cgi-bin/nph-zms {
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $request_filename;
+        fastcgi_pass  unix:/var/run/fcgiwrap/fcgiwrap.sock;
+    }
 
-	location = /cgi-bin/nph-zms {
-		include fastcgi_params;
-		fastcgi_param   SCRIPT_FILENAME $document_root$fastcgi_script_name;
-		fastcgi_pass    unix:/var/run/fcgiwrap/fcgiwrap.sock;
-	}
+    location /zm/cache {
+        alias /var/cache/zoneminder;
+    }
 
-	location ~ \.php$ { 
-		include fastcgi_params;
-		fastcgi_param   SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-		fastcgi_pass    unix:/var/run/php-fpm.sock;
-	}
+    location /zm {
+        alias   /usr/local/www/zoneminder;
 
-	location /api {
-		rewrite ^/api/(.+)$ /api/index.php?p=$1 last;
-	}
+        location ~ \.php$ {
+            if (!-f $request_filename) { return 404; }
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $request_filename;
+            fastcgi_index index.php;
+            fastcgi_pass unix:/var/run/php-fpm.sock;
+        }
 
+        location ~ \.(jpg|jpeg|gif|png|ico)$ {
+            access_log      off;
+            expires 33d;
+        }
+
+        location /zm/api/ {
+            alias   /usr/local/www/zoneminder;
+            rewrite ^/zm/api(.+)$ /zm/api/app/webroot/index.php?p=$1 last;
+        }
+    }
 }


### PR DESCRIPTION
From
https://svnweb.freebsd.org/ports/head/multimedia/zoneminder/files/README.FreeBSD?revision=486990&view=co,
the key takeaway is this line:

        - web interface has several hardcoded /zm in url generation, so
        it is mandatory to serve your installtion from /zm subfolder

Which means that the recommendations in the same file must be adhered
to.  This updates the nginx config accordingly, fixing
https://redmine.ixsystems.com/issues/66187 in the process.