### PR TITLE
README.md clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ match the other one. Once the key and certificate match each other all is good.
 A way to avoid that would be for iocage not to call the `servicerestart` command
 when setting multiple values, but it does not do that at present. Another way would
 be to only make one of the two settings require a restart, but that would be
-error-prone in other way.
+error-prone in other ways.
 
 ### Admin UI issue
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ possible to replace the ui.json with this to make it work automatically:
 	"%%S%%": "adminprotocol",
 	"%%P%%": "adminport"
     },
-    "docurl": "https://github.com/RafalLukawiecki/iocage-plugin-zoneminder"
+    "docurl": "https://github.com/freenas/iocage-plugin-zoneminder"
 }
 ```

--- a/ui.json
+++ b/ui.json
@@ -1,4 +1,4 @@
 {
     "adminportal": "https://%%IP%%/zm",
-    "docurl": "https://github.com/RafalLukawiecki/iocage-plugin-zoneminder"
+    "docurl": "https://github.com/freenas/iocage-plugin-zoneminder"
 }


### PR DESCRIPTION
Added link to the iocage bug that prevents full functioning of adminportal_placeholders and an explanation of possible errors when changing sslkey and sslcert. No code changed.